### PR TITLE
Add workflow for github actions with only tests runs

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -1,10 +1,8 @@
-name: Ruby Gem
+name: Test & Release
 
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+    branches: [ release ]
 
 jobs:
   build:
@@ -21,18 +19,6 @@ jobs:
       run: |
         bundle install
         bundle exec rspec
-    # - name: Publish to GPR
-    #   run: |
-    #     mkdir -p $HOME/.gem
-    #     touch $HOME/.gem/credentials
-    #     chmod 0600 $HOME/.gem/credentials
-    #     printf -- "---\n:github: Bearer ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-    #     gem build *.gemspec
-    #     gem push --KEY github --host https://rubygems.pkg.github.com/${OWNER} *.gem
-    #   env:
-    #     GEM_HOST_API_KEY: ${{secrets.GPR_AUTH_TOKEN}}
-    #     OWNER: driggl
-
     - name: Publish to RubyGems
       run: |
         mkdir -p $HOME/.gem

--- a/.github/workflows/gem-test.yml
+++ b/.github/workflows/gem-test.yml
@@ -1,0 +1,23 @@
+name: Run tests
+
+on:
+  push:
+    branches-ignore: [ release ]
+  pull_request:
+    branches: [ master release ]
+
+jobs:
+  build:
+    name: Build + Test
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby 2.7.1
+      uses: actions/setup-ruby@v1
+      with:
+        version: 2.7.x
+    - name: Run tests
+      run: |
+        bundle install
+        bundle exec rspec


### PR DESCRIPTION
### Overview

Currently, every push/PR to master will trigger complete gem build, test run and publication.
But sometimes we don't want to release new version, when for example, only Readme or CI config is updated.

However, gem push with already published version will fail.

### Suggestions: 

- Automatic gem version publication only happens on `release` branch
- On all branches, and pull requests against master the tests are being triggered without version publication
